### PR TITLE
add MC6847 CG2,3,6 modes

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "dithertron",
-  "version": "1.0.17",
+  "version": "1.0.18",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "dithertron",
-      "version": "1.0.17",
+      "version": "1.0.18",
       "license": "ISC",
       "dependencies": {
         "@types/jquery": "^3.5.0",

--- a/src/export.ts
+++ b/src/export.ts
@@ -297,6 +297,22 @@ function exportVCSPlayfield(img: PixelsAvailableMessage, settings: DithertronSet
     return char;
 }
 
+function exportMC6847(img: PixelsAvailableMessage, settings: DithertronSettings): Uint8Array {    
+    var char = new Uint8Array(img.width*img.height/4);
+    let dptr = 0;
+    let sptr = 0;
+    for (var y = 0; y < img.height; y++) {
+        for (var x = 0; x < img.width; x+=4, sptr+=4) {
+            char[dptr++] = ((img.indexed[sptr+0] & 0b11 ) << 6)+ 
+                           ((img.indexed[sptr+1] & 0b11 ) << 4)+ 
+                           ((img.indexed[sptr+2] & 0b11 ) << 2)+ 
+                           ((img.indexed[sptr+3] & 0b11 ) << 0);
+        }
+    }
+    console.log(char);
+    return char;
+}
+
 //
 
 function convertToSystemPalette(pal: Uint32Array, syspal: Uint32Array | number[]) {

--- a/src/palettes.ts
+++ b/src/palettes.ts
@@ -224,6 +224,20 @@ const AMIGA_OCS_COLOR_RGB = RGB_444;
 const IIGS_COLOR_RGB = RGB_444;
 const GAMEGEAR_COLOR_RGB = RGB_444;
 
+const MC6847_PALETTE0 = [
+   RGB(0x30, 0xd2, 0x00),    /* NTSC: RGB( 28, 213,  16), */   // green 
+   RGB(0xf5, 0xf5, 0x80),    /* NTSC: RGB(226, 219,  15), */   // yellow
+   RGB(0x4c, 0x3a, 0xb4),    /* NTSC: RGB(  3,  32, 255), */   // blue  
+   RGB(0x9a, 0x32, 0x36),    /* NTSC: RGB(226,  32,  10), */   // red   
+];    
+
+const MC6847_PALETTE1 = [
+   RGB(0xd8, 0xd8, 0xd8),    /* NTSC: RGB( 205, 219, 224), */  // buff    
+   RGB(0x41, 0xaf, 0x71),    /* NTSC: RGB(  22, 208, 226), */  // cyan    
+   RGB(0xd8, 0x6e, 0xf0),    /* NTSC: RGB( 203,  57, 226), */  // magenta 
+   RGB(0xd4, 0x7f, 0x00),    /* NTSC: RGB( 204,  45,  16), */  // orange  
+];    
+
 function generateRGBPalette(rr,gg,bb) {
     var n = 1<<(rr+gg+bb);
     var rs = 255 / ((1<<rr)-1);

--- a/src/systems.ts
+++ b/src/systems.ts
@@ -484,6 +484,72 @@ const SYSTEMS : DithertronSettings[] = [
         pal:ATARIST_RGB,
         reduce:16
     },
+    {
+        id:'MC6847.CG2.palette0',
+        name:'MC6847 CG2 (palette 0)',
+        width:128,
+        height:64,
+        scaleX: 1/1.3,
+        conv:'DitheringCanvas',
+        pal:MC6847_PALETTE0,
+        reduce:4,
+        toNative:'exportMC6847'
+    },
+    {
+        id:'MC6847.CG2.palette1',
+        name:'MC6847 CG2 (palette 1)',
+        width:128,
+        height:64,
+        scaleX: 1/1.3,
+        conv:'DitheringCanvas',
+        pal:MC6847_PALETTE1,
+        reduce:4,
+        toNative:'exportMC6847'
+    },
+    {
+        id:'MC6847.CG3.palette0',
+        name:'MC6847 CG3 (palette 0)',
+        width:128,
+        height:96,
+        scaleX: 1/1.3*96/64,
+        conv:'DitheringCanvas',
+        pal:MC6847_PALETTE0,
+        reduce:4,
+        toNative:'exportMC6847'
+    },
+    {
+        id:'MC6847.CG3.palette1',
+        name:'MC6847 CG3 (palette 1)',
+        width:128,
+        height:96,
+        scaleX: 1/1.3*96/64,
+        conv:'DitheringCanvas',
+        pal:MC6847_PALETTE1,
+        reduce:4,
+        toNative:'exportMC6847'
+    },
+    {
+        id:'MC6847.CG6.palette0',
+        name:'MC6847 CG6 (palette 0)',
+        width:128,
+        height:192,
+        scaleX: 1/1.3*192/64,
+        conv:'DitheringCanvas',
+        pal:MC6847_PALETTE0,
+        reduce:4,
+        toNative:'exportMC6847'
+    },
+    {
+        id:'MC6847.CG6.palette1',
+        name:'MC6847 CG6 (palette 1)',
+        width:128,
+        height:192,
+        scaleX: 1/1.3*192/64,
+        conv:'DitheringCanvas',
+        pal:MC6847_PALETTE1,
+        reduce:4,
+        toNative:'exportMC6847'
+    }
 ];
 var SYSTEM_LOOKUP = {};
 SYSTEMS.forEach((sys) => { if (sys) SYSTEM_LOOKUP[sys.id||sys.name] = sys; });


### PR DESCRIPTION
this PR adds some graphic modes for the Motorola MC6847 video chip:

CG2: 128x64 x 4 colors (2 palettes)
CG3: 128x96 x 4 colors (2 palettes)
CG6: 128x192 x 4 colors (2 palettes)

The MC6847 appeared in several 8 bit computers, including Dragon32, TRS80 Coco, MC10, Laser 210/VZ200 and so on...