### PR TITLE
Added C64 Multi FLI (MCI) support

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "dithertron",
-  "version": "1.0.18",
+  "version": "1.1.19",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "dithertron",
-      "version": "1.0.18",
+      "version": "1.1.19",
       "license": "ISC",
       "dependencies": {
         "@types/jquery": "^3.5.0",
@@ -23,17 +23,17 @@
       }
     },
     "node_modules/@types/jquery": {
-      "version": "3.5.16",
-      "resolved": "https://registry.npmjs.org/@types/jquery/-/jquery-3.5.16.tgz",
-      "integrity": "sha512-bsI7y4ZgeMkmpG9OM710RRzDFp+w4P1RGiIt30C1mSBT+ExCleeh4HObwgArnDFELmRrOpXgSYN9VF1hj+f1lw==",
+      "version": "3.5.25",
+      "resolved": "https://registry.npmjs.org/@types/jquery/-/jquery-3.5.25.tgz",
+      "integrity": "sha512-gykx2c+OZf5nx2tv/5fDQqmvGgTiXshELy5jf9IgXPtVfSBl57IUYByN4osbwMXwJijWGOEYQABzGaFZE79A0Q==",
       "dependencies": {
         "@types/sizzle": "*"
       }
     },
     "node_modules/@types/sizzle": {
-      "version": "2.3.3",
-      "resolved": "https://registry.npmjs.org/@types/sizzle/-/sizzle-2.3.3.tgz",
-      "integrity": "sha512-JYM8x9EGF163bEyhdJBpR2QX1R5naCJHC8ucJylJ3w9/CVBaskdQ8WqBf8MmQrd1kRvp/a4TS8HJ+bxzR7ZJYQ=="
+      "version": "2.3.5",
+      "resolved": "https://registry.npmjs.org/@types/sizzle/-/sizzle-2.3.5.tgz",
+      "integrity": "sha512-tAe4Q+OLFOA/AMD+0lq8ovp8t3ysxAOeaScnfNdZpUxaGl51ZMDEITxkvFl1STudQ58mz6gzVGl9VhMKhwRnZQ=="
     },
     "node_modules/bootstrap": {
       "version": "4.6.2",
@@ -71,9 +71,9 @@
       }
     },
     "node_modules/cropperjs": {
-      "version": "1.5.13",
-      "resolved": "https://registry.npmjs.org/cropperjs/-/cropperjs-1.5.13.tgz",
-      "integrity": "sha512-by7jKAo73y5/Do0K6sxdTKHgndY0NMjG2bEdgeJxycbcmHuCiMXqw8sxy5C5Y5WTOTcDGmbT7Sr5CgKOXR06OA=="
+      "version": "1.6.1",
+      "resolved": "https://registry.npmjs.org/cropperjs/-/cropperjs-1.6.1.tgz",
+      "integrity": "sha512-F4wsi+XkDHCOMrHMYjrTEE4QBOrsHHN5/2VsVAaRq8P7E5z7xQpT75S+f/9WikmBEailas3+yo+6zPIomW+NOA=="
     },
     "node_modules/file-saver": {
       "version": "2.0.5",
@@ -94,9 +94,9 @@
       "integrity": "sha512-l+8esYHTKOx2G/Aao4lEQ0bnHWg4fWtJbVoZZT9Knxi01pB8C80BR85nONLFwkkQoFRCmXY+BUcGZN3yZ2QsRA=="
     },
     "node_modules/jquery": {
-      "version": "3.6.4",
-      "resolved": "https://registry.npmjs.org/jquery/-/jquery-3.6.4.tgz",
-      "integrity": "sha512-v28EW9DWDFpzcD9O5iyJXg3R3+q+mET5JhnjJzQUZMHOv67bpSIHq81GEYpPNZHG+XXHsfSme3nxp/hndKEcsQ=="
+      "version": "3.7.1",
+      "resolved": "https://registry.npmjs.org/jquery/-/jquery-3.7.1.tgz",
+      "integrity": "sha512-m4avr8yL8kmFN8psrbFFFmB/If14iN5o9nw/NgnnM+kybDJpRsAynV2BsfpTYrTRysYUdADVD7CkUUizgkpLfg=="
     },
     "node_modules/multimath": {
       "version": "2.0.0",
@@ -138,16 +138,16 @@
       }
     },
     "node_modules/typescript": {
-      "version": "5.0.4",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.0.4.tgz",
-      "integrity": "sha512-cW9T5W9xY37cc+jfEnaUvX91foxtHkza3Nw3wkoF4sSlKn0MONdkdEndig/qPBWXNkmplh3NzayQzCiHM4/hqw==",
+      "version": "5.2.2",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.2.2.tgz",
+      "integrity": "sha512-mI4WrpHsbCIcwT9cF4FZvr80QUeKvsUsUvKDoR+X/7XHQH98xYD8YHZg7ANtz2GtZt/CBq2QJ0thkGJMHfqc1w==",
       "dev": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
       },
       "engines": {
-        "node": ">=12.20"
+        "node": ">=14.17"
       }
     },
     "node_modules/webworkify": {
@@ -158,17 +158,17 @@
   },
   "dependencies": {
     "@types/jquery": {
-      "version": "3.5.16",
-      "resolved": "https://registry.npmjs.org/@types/jquery/-/jquery-3.5.16.tgz",
-      "integrity": "sha512-bsI7y4ZgeMkmpG9OM710RRzDFp+w4P1RGiIt30C1mSBT+ExCleeh4HObwgArnDFELmRrOpXgSYN9VF1hj+f1lw==",
+      "version": "3.5.25",
+      "resolved": "https://registry.npmjs.org/@types/jquery/-/jquery-3.5.25.tgz",
+      "integrity": "sha512-gykx2c+OZf5nx2tv/5fDQqmvGgTiXshELy5jf9IgXPtVfSBl57IUYByN4osbwMXwJijWGOEYQABzGaFZE79A0Q==",
       "requires": {
         "@types/sizzle": "*"
       }
     },
     "@types/sizzle": {
-      "version": "2.3.3",
-      "resolved": "https://registry.npmjs.org/@types/sizzle/-/sizzle-2.3.3.tgz",
-      "integrity": "sha512-JYM8x9EGF163bEyhdJBpR2QX1R5naCJHC8ucJylJ3w9/CVBaskdQ8WqBf8MmQrd1kRvp/a4TS8HJ+bxzR7ZJYQ=="
+      "version": "2.3.5",
+      "resolved": "https://registry.npmjs.org/@types/sizzle/-/sizzle-2.3.5.tgz",
+      "integrity": "sha512-tAe4Q+OLFOA/AMD+0lq8ovp8t3ysxAOeaScnfNdZpUxaGl51ZMDEITxkvFl1STudQ58mz6gzVGl9VhMKhwRnZQ=="
     },
     "bootstrap": {
       "version": "4.6.2",
@@ -190,9 +190,9 @@
       }
     },
     "cropperjs": {
-      "version": "1.5.13",
-      "resolved": "https://registry.npmjs.org/cropperjs/-/cropperjs-1.5.13.tgz",
-      "integrity": "sha512-by7jKAo73y5/Do0K6sxdTKHgndY0NMjG2bEdgeJxycbcmHuCiMXqw8sxy5C5Y5WTOTcDGmbT7Sr5CgKOXR06OA=="
+      "version": "1.6.1",
+      "resolved": "https://registry.npmjs.org/cropperjs/-/cropperjs-1.6.1.tgz",
+      "integrity": "sha512-F4wsi+XkDHCOMrHMYjrTEE4QBOrsHHN5/2VsVAaRq8P7E5z7xQpT75S+f/9WikmBEailas3+yo+6zPIomW+NOA=="
     },
     "file-saver": {
       "version": "2.0.5",
@@ -210,9 +210,9 @@
       "integrity": "sha512-l+8esYHTKOx2G/Aao4lEQ0bnHWg4fWtJbVoZZT9Knxi01pB8C80BR85nONLFwkkQoFRCmXY+BUcGZN3yZ2QsRA=="
     },
     "jquery": {
-      "version": "3.6.4",
-      "resolved": "https://registry.npmjs.org/jquery/-/jquery-3.6.4.tgz",
-      "integrity": "sha512-v28EW9DWDFpzcD9O5iyJXg3R3+q+mET5JhnjJzQUZMHOv67bpSIHq81GEYpPNZHG+XXHsfSme3nxp/hndKEcsQ=="
+      "version": "3.7.1",
+      "resolved": "https://registry.npmjs.org/jquery/-/jquery-3.7.1.tgz",
+      "integrity": "sha512-m4avr8yL8kmFN8psrbFFFmB/If14iN5o9nw/NgnnM+kybDJpRsAynV2BsfpTYrTRysYUdADVD7CkUUizgkpLfg=="
     },
     "multimath": {
       "version": "2.0.0",
@@ -246,9 +246,9 @@
       "peer": true
     },
     "typescript": {
-      "version": "5.0.4",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.0.4.tgz",
-      "integrity": "sha512-cW9T5W9xY37cc+jfEnaUvX91foxtHkza3Nw3wkoF4sSlKn0MONdkdEndig/qPBWXNkmplh3NzayQzCiHM4/hqw==",
+      "version": "5.2.2",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.2.2.tgz",
+      "integrity": "sha512-mI4WrpHsbCIcwT9cF4FZvr80QUeKvsUsUvKDoR+X/7XHQH98xYD8YHZg7ANtz2GtZt/CBq2QJ0thkGJMHfqc1w==",
       "dev": true
     },
     "webworkify": {

--- a/src/systems.ts
+++ b/src/systems.ts
@@ -12,6 +12,17 @@ const SYSTEMS : (DithertronSettings|null)[] = [
         toNative:'exportC64Multi',
     },
     {
+        id:'c64.multi.fli',
+        name:'C-64 Multi FLI',
+        width:160,
+        height:200,
+        scaleX:0.936*2,
+        conv:'VICII_Multi_CanvasFLI',
+        pal:VIC_PAL_RGB,
+        block:{w:4,h:1,colors:4,cbw:4,cbh:8},
+        toNative:'exportC64Multi',
+    },
+    {
         id:'c64.hires',
         name:'C-64 Hires',
         width:320,


### PR DESCRIPTION
The C64 Multi FLI uses a 4x1 screen block size allowing a background color, two screen ram color choices, and a third "color block" color choice option. The color block is 8x8 in size and stored in the VIC color ram in a fixed memory location. The C64 screen ram color choices can be adjusted per scan line (as done in FLI) but the color block ram address cannot be dynamically changed). The sample code changes screen ram address banks per Y scan line but leaves the color block ram alone as insufficient remaining CPU time exists to do any meaningful changes to the color block ram.

Both C64 Multi FLI and Hires FLI have the "bad scan line" bug present in the example source code. The first 3 character columns on the PAL screen will not have color information because the VIC is stalled on CPU wait cycles and thus the character color data is not available when the scan line starts to draw (and the VIC uses pixel colors that happen to remain in the registers at the time of the bad scan line is invoked). This is a known bug with the FLI technique without a solution. Most developers work around thus limitation by filling the screen character ram with a 00 pixel pattern so the pixels are transparent and display the standard background color instead. Emulators (and SCPU) however can "fix" this bug and display the full 160x200 picture but this fix is outside the scope of tool and example code.