### PR TITLE
Added FLI bad line bug processing and misc

### DIFF
--- a/src/systems.ts
+++ b/src/systems.ts
@@ -8,7 +8,7 @@ const SYSTEMS : (DithertronSettings|null)[] = [
         scaleX:0.936*2,
         conv:'VICII_Multi_Canvas',
         pal:VIC_PAL_RGB,
-        block:{w:4,h:8,colors:4},
+        block:{w:4,h:8,colors:4,cbw:4,cbh:8},
         toNative:'exportC64Multi',
     },
     {
@@ -17,9 +17,10 @@ const SYSTEMS : (DithertronSettings|null)[] = [
         width:160,
         height:200,
         scaleX:0.936*2,
-        conv:'VICII_Multi_CanvasFLI',
+        conv:'VICII_Multi_Canvas',
         pal:VIC_PAL_RGB,
         block:{w:4,h:1,colors:4,cbw:4,cbh:8},
+        fli:{bug:false,blankLeft:false,blankRight:false,blankColumns:3},
         toNative:'exportC64Multi',
     },
     {


### PR DESCRIPTION
In FLI mode, the VIC chip is forced to reload color data per raster
line. The issue is that for the first 24 pixels there's no color data
available, leaving terrible grey, orange and the background as
the only choices available. This code is able to factor this limitation
during the dithering process in an attempt to do the best job
given a bad scenario.

Alternatively, the settings can be enabled be changed to "fill"
the bad line area with background (reducing the draw width by 24 or
48 pixels in the process).

Misc:
-reverted logic that stops processing color block after certain
iteration count as it can pick colors that it shouldn't instead using
the color block (and the new logic does a better job)
- improvement: speed was made faster regarding the recalculation of
the color block when the first pixel of the first row of each block
is calculated thus ensuring the color blocks are always calculated first
- improvement: The multi and multi FLI code are merged since the logic
 is cabable or performing both jobs
- fix: the chocie of border and background colors were not being stored
and loaded properly in the assembly example
- fix: blanking of an area in FLI was not correctly choosing the
background color if any pixel index had the same color chosen
(which can happen in FLI mode since color choices are limited)