### PR TITLE
Added Vic 20 cell based export support

### DIFF
--- a/src/common/types.ts
+++ b/src/common/types.ts
@@ -57,6 +57,11 @@ export interface DithertronSettings {
         xb?: number,            // how much color bleeds from the surrounding x/y direction (default=0)
         yb?: number
     };
+    cell?: {                    // for displays that are character cell based
+        w: number,              // how many pixels wide is each character's cell (for completeness)
+        h: number,              // how many pixels tall is each character's cell (which can differ from the block, e.g. fli)
+        msbToLsb: boolean       // set to true if the image is ordered most significant bit to least significant bit
+    };
     paletteChoices?: PaletteChoices;
     cb?: {                      // color block (for mods with separated color blocks outside of the pixel color choice)
         w: number,

--- a/src/dither/canvas.ts
+++ b/src/dither/canvas.ts
@@ -183,7 +183,7 @@ export class VICII_Canvas extends ParamDitherCanvas {
         // find global colors
         this.prepareGlobalColorChoices();
 
-        this.bitsPerColor = Math.floor(Math.log2(this.colors));
+        this.bitsPerColor = Math.ceil(Math.log2(this.colors));
         this.pixelsPerByte = Math.floor(8 / this.bitsPerColor);
 
         // offset into the first byte of the color ram (which is after the screen data)

--- a/src/export/exportfuncs.ts
+++ b/src/export/exportfuncs.ts
@@ -1,4 +1,5 @@
 import { DithertronSettings, PixelEditorImageFormat, PixelsAvailableMessage } from "../common/types";
+import { hex } from "../common/util";
 
 function remapBits(x: number, arr?: number[]): number {
     if (!arr) return x;
@@ -109,12 +110,10 @@ export function exportApple2HiresToHGR(img: PixelsAvailableMessage, settings: Di
     return data;
 }
 
-// TODO: support VIC-20
 export function exportCharMemory(img: PixelsAvailableMessage,
     w: number,
     h: number,
-    type?: 'zx' | 'fli',
-    bgColor?: number): Uint8Array {
+    type?: 'zx' | 'fli'): Uint8Array {
     var bpp = (w == 4) ? 2 : 1; // C64-multi vs C64-hires & ZX
     var i = 0;
     var cols = img.width / w;
@@ -147,18 +146,6 @@ export function exportCharMemory(img: PixelsAvailableMessage,
                     idx = 3; // for bit pattern %11
             }
 
-            // Force override that the color choice MUST be the background color
-            // if the palette index matches the background color even if one of
-            // the other colors might happen to be set to the background color too.
-            // This is requires as the FLI bug on C64s will choose the last color
-            // block color as 0xff (grey) even if another color is specified but
-            // will correctly choose the screen color if the pixel index is 0.
-            // But the right block color might be set to the background color too
-            // which would cause a match to the color block color/screen colors
-            // instead of the background color as required for the FLI bug.
-            if ((bgColor != undefined) && (bgColor === palidx))
-                idx = 0;
-
             char[ofs] |= idx << shift;
             i++;
         }
@@ -166,126 +153,295 @@ export function exportCharMemory(img: PixelsAvailableMessage,
     return char;
 }
 
-export function exportC64Multi(img: PixelsAvailableMessage, settings: DithertronSettings): Uint8Array {
-    if (!settings.block) throw "No block size";
+export function bitOverlayUint8Array(
+    array: Uint8Array,
+    offset: number,
+    bitPattern: number,
+    bitShift: number,
+    bitCount: number,
+    littleEndian?: boolean): void {
+
+    // This routine is capable of overlaying bit patterns onto a memory
+    // buffer. The routine handles small or large bit patterns (so long as the
+    // bit pattern can reasonably fit within the "number" type, including any
+    // bit shifting that may be needed).
+    //
+    // The endianness of the pattern only applies if the pixel may cross the byte
+    // boundary, in which case the routine will factor the byte direction when
+    // overlaying the bit pattern onto the memory buffer.
+
+    littleEndian = littleEndian === undefined ? true : littleEndian;
+
+    let bitFilter = (1 << bitCount) - 1;
+    let pattern = (bitPattern & bitFilter);
+
+    let bitOverlay = pattern << bitShift;
+    bitFilter <<= bitShift;
+
+    offset += (littleEndian ? 0 : ((bitCount + bitShift - 1) / 8));
+    let direction = littleEndian ? 1 : -1;
+
+    for (let bitsRemaining = bitCount + bitShift; bitsRemaining > 0; bitsRemaining -= 8, offset += direction) {
+        let complimentFilter = (~0) ^ bitFilter;
+
+        let complimentByte = complimentFilter & 0xff;
+        let overlayByte = bitOverlay & 0xff;
+
+        console.assert(offset < array.length);
+        array[offset] = (array[offset] & complimentByte) | overlayByte;
+
+        bitOverlay >>= 8;
+        bitFilter >>= 8;
+    }
+}
+
+interface CellExporter {
+    prepare(width: number, height: number): { totalBytes: number, littleEndian?: boolean };
+    xyToBitInfo(x: number, y: number, paletteIndex: number): { offset: number, bitShift: number, bitCount: number, bitPattern: number };
+}
+
+export function exportCellBuffer(
+    img: PixelsAvailableMessage,
+    exporter: CellExporter
+) : Uint8Array
+{
+    let setup = exporter.prepare(img.width, img.height);
+    setup.littleEndian = setup.littleEndian === undefined ? true : setup.littleEndian;
+
+    let array = new Uint8Array(setup.totalBytes);
+    for (let i = 0, y = 0; y < img.height; ++y) {
+        for (let x = 0; x < img.width; ++x, ++i) {
+            let info = exporter.xyToBitInfo(x, y, img.indexed[i]);
+            bitOverlayUint8Array(array, info.offset, info.bitPattern, info.bitShift, info.bitCount, setup.littleEndian);
+        }
+    }
+    return array;
+}
+
+function exportIndexedPaletteAndCellBasedImage(
+    img: PixelsAvailableMessage,
+    settings: DithertronSettings,
+    globalColors: { paletteIndex: number, bitPattern: number }[],
+    colorChoicesBitPattern: number[]): Uint8Array {
+
+    if (settings.block === undefined)
+        throw "Block size not specified";
+    if (settings.cell === undefined)
+        throw "Cell size not specified";
+
     let w = settings.block.w;
     let h = settings.block.h;
-    let cols = img.width / w;
-    let rows = img.height / h;
 
-    let isUsingFli = !(settings.fli === undefined);
-    let cbOffset: number = (img.width / w * img.height / h);
-    let cbw: number = settings.cb.w === undefined ? w : settings.cb.w;
-    let cbh: number = settings.cb.h === undefined ? h : settings.cb.h;
+    let bpp = Math.ceil(Math.log2(settings.block.colors));
+    let bitsPerCellWidth = (settings.cell.w * bpp);
+    let bitsPerCell = settings.cell.h * bitsPerCellWidth;
+    let bytesPerCell = Math.ceil(bitsPerCell / 8);
+    let cellBytesPerRow = 0;
 
-    let cbcols = img.width / cbw;
-    let cbrows = img.height / cbh;
+    let columns: number = 0;
 
-    let screen = new Uint8Array(isUsingFli ? 0x2000 : (cols * rows));
-    let color = new Uint8Array(cbcols * cbrows);
+    let exporter: CellExporter = {
 
-    // Normally in multi-color mode each screen pixel in a 4x8 block choses from two
-    // color options from screen ram which stores color palette choice one is the
-    // lower screen nybble and color choice two in the upper screen nybble. However,
-    // in FLI mode each pixel row gets a new choice of colors since on each scan line
-    // special code swaps the screen color ram pointer location to a new location in
-    // memory thus allowing for independent values per row.
+        prepare(width: number, height: number): { totalBytes: number, littleEndian?: boolean } {
+            columns = (width / w);
+            cellBytesPerRow = columns * bytesPerCell;
+            //console.log('prepare', bpp, bitsPerCellWidth, bitsPerCell, bytesPerCell, columns, cellBytesPerRow, img.width * img.height * bpp / 8);
+            return { totalBytes: img.width * img.height * bpp / 8 };
+        },
+
+        xyToBitInfo(x: number, y: number, paletteIndex: number): { offset: number, bitShift: number, bitCount: number, bitPattern: number } {
+
+            let col = Math.floor(x / w);
+
+            // which cell is being filled
+            let cellCol = Math.floor(x / settings.cell.w);
+            let cellRow = Math.floor(y / settings.cell.h);
+
+            let paramOffset = (Math.floor(y / h) * columns) + col;
+            console.assert(paramOffset < img.params.length - 1);    // must be within the bounds of the param array
+            let param = img.params[paramOffset];
+
+            // where is the start of the cell being filled located in the byte array
+            let cellColOffset = bytesPerCell * cellCol;
+            let cellRowOffset = cellBytesPerRow * cellRow;
+
+            // which particular byte of the cell is being filled now
+            let cellXOffset = Math.floor(((x % settings.cell.w) * bpp) / 8);
+            let cellYOffset = Math.floor(((y % settings.cell.h) * bitsPerCellWidth) / 8);
+
+            // how much of a bit offset is required for this particular pixel
+            let bitShift = (settings.cell.msbToLsb ? (bitsPerCellWidth - (((x % settings.cell.w) + 1) * bpp)) : (x % settings.cell.w) * bpp);
+
+            let result = {
+                offset: cellRowOffset + cellColOffset + cellYOffset + cellXOffset,
+                bitShift: bitShift,
+                bitCount: bpp,
+                bitPattern: 0
+            };
+
+            let c1 = param & 0xf;
+            let c2 = (param & 0xf0) >> 4;
+            let c3 = (param & 0xf00) >> 8;
+
+            // first can the global colors for a match
+            for (let i = 0; i < globalColors.length; ++i) {
+                if (paletteIndex == globalColors[i].paletteIndex) {
+                    result.bitPattern = globalColors[i].bitPattern;
+                    return result;
+                }
+            }
+
+            // next scan the color choices for a match
+            switch (paletteIndex) {
+                case c1: {
+                    console.assert(colorChoicesBitPattern.length > 0);
+                    result.bitPattern = colorChoicesBitPattern[0];
+                    break;
+                }
+                case c2: {
+                    console.assert(colorChoicesBitPattern.length > 1);
+                    result.bitPattern = colorChoicesBitPattern[1];
+                    break;
+                }
+                case c3: {
+                    console.assert(colorChoicesBitPattern.length > 2);
+                    result.bitPattern = colorChoicesBitPattern[2];
+                    break;
+                }
+            }
+
+            return result;
+        }
+    };
+
+    return exportCellBuffer(img, exporter);
+}
+
+interface ExportVic {
+    img: PixelsAvailableMessage;
+    settings: DithertronSettings;
+    globalColors: { paletteIndex: number, bitPattern: number }[];
+    cellColors: number[];
+    paramToScreen(param: number): number;
+    paramToColorBlock(param: number): number;
+    extraArray(): Uint8Array | undefined;
+}
+
+export function exportVic(options: ExportVic): Uint8Array {
+    if (options.settings.block == undefined)
+        throw "No block size";
+
+    let isUsingFli = !(options.settings.fli === undefined);
+    let isUsingCb = !(options.settings.cb === undefined);
+
+    let cellImage = exportIndexedPaletteAndCellBasedImage(options.img, options.settings, options.globalColors, options.cellColors);
+
+    let w = options.settings.block.w;
+    let h = options.settings.block.h;
+    let columns = Math.floor(options.img.width / options.settings.cell.w);
+    let rows = Math.floor(options.img.height / options.settings.cell.h);
+    let bpp = Math.ceil(Math.log2(options.settings.block.colors));
+
+    let cbOffset: number = Math.floor((options.img.width / w) * (options.img.height / h));
+    let cbw: number = (isUsingCb ? options.settings.cb.w === undefined ? w : options.settings.cb.w : w);
+    let cbh: number = (isUsingCb ? options.settings.cb.h === undefined ? h : options.settings.cb.h : h);
+
+    let cbCols = options.img.width / cbw;
+    let cbRows = options.img.height / cbh;
+
+    let screenBytes = (columns * rows);
+    let screenAlignedBytes = (1 << Math.ceil(Math.log2(screenBytes)));
+
+    let screen = new Uint8Array(isUsingFli ? (screenAlignedBytes * options.settings.cell.h) : (columns * rows));
+    let color: Uint8Array | undefined = (isUsingCb ? new Uint8Array(cbCols * cbRows) : undefined);
+
+    // Normally in hires mode each screen pixel in a 4x8 or 8x8 block chooses from
+    // cell colors dedicated for the entire block (stored in "screen" color ram).
+    // However, in FLI mode each pixel row gets a new choice of colors since on
+    // each scan line special code swaps the screen color ram pointer location to
+    // a new location in memory thus allowing for independent values per row.
     if (isUsingFli) {
         for (let i = 0; i < cbOffset; i++) {
-            let p = img.params[i];
-            let scrnofs = (Math.floor(i / 40) & 7) * 0x400 + Math.floor(i / 320) * 40 + (i % 40);
-            //if (i < 500) console.log(scrnofs, i, hex(i), (Math.floor(i/40)&7), ((Math.floor(i/40)&7)*0x400), (Math.floor(i/320)), (i % 40), (Math.floor(i/320)*40 + (i % 40)));
-            screen[scrnofs] = (p & 0xff);
+            let p = options.img.params[i];
+            let screenOffset = (Math.floor(i / columns) & (options.settings.cell.h - 1)) * screenAlignedBytes + (Math.floor(i / (bpp * options.img.width)) * columns) + (i % columns);
+            //if (i < 500) console.log(screenOffset, columns, (options.settings.cell.h - 1), screenAlignedBytes, w, options.img.width, i, hex(i), (Math.floor(i/40)&7), ((Math.floor(i/40)&7)*0x400), (Math.floor(i/320)), (i % 40), (Math.floor(i/320)*40 + (i % 40)));
+            screen[screenOffset] = options.paramToScreen(p);
         }
     } else {
         for (let i = 0; i < screen.length; i++) {
-            screen[i] = (img.params[i] & 0xff);
+            screen[i] = options.paramToScreen(options.img.params[i]);
         }
     }
 
-    for (let i = 0; i < color.length; i++) {
-        // The FLI version separates out the color block ram from the
-        // normal param area whereas the non-FLI version stores the
-        // color block in the 2nd most least significant byte's lower
-        // of each chosen color. In both cases, the color block area
-        // is exactly the same size since they represent the pixel index
-        // value choice of %11 and the color block ram is not relocatable
-        // on the C64 (unlike the screen ram color choices).
-        color[i] = (img.params[i + cbOffset] & 0xf);
+    for (let i = 0; i < (isUsingCb ? color.length : 0); i++) {
+        // The color block ram is split out from the normal param area
+        // to stored extra color block choices shared across
+        // multiple pixels. The color block area is an extra shared
+        // color ram that is independent of the "screen" color ram.
+        color[i] = options.paramToColorBlock(options.img.params[i + cbOffset]);
     }
-    let char = exportCharMemory(img, w, cbh, isUsingFli ? 'fli' : undefined, (img.params[img.params.length - 1] & 0xf));
-    let xtraword = img.params[img.params.length - 1]; // background, border colors
-    let xtra = new Uint8Array(2);
-    xtra[0] = xtraword & 0xff;          // background color (and high nybble aux)
-    xtra[1] = (xtraword >> 8) & 0xff;   // border color
-    return concatArrays([char, screen, color, xtra]);
+
+    let extra = options.extraArray();
+
+    let mergeArrays = [cellImage, screen, color, extra];
+    if (color === undefined)
+        mergeArrays.splice(2, 1);
+    if (extra === undefined)
+        mergeArrays.splice(mergeArrays.length - 1, 1);
+
+    return concatArrays(mergeArrays);
+}
+
+export function exportC64Multi(img: PixelsAvailableMessage, settings: DithertronSettings): Uint8Array {
+
+    let extraWord = img.params[img.params.length - 1]; // background, border colors
+
+    // background for bit pattern %00
+    // lower nybble for bit pattern %10
+    // upper nybble for bit pattern %01
+    // color block nybble for bit pattern %11
+    return exportVic({
+        img: img,
+        settings: settings,
+        globalColors: [{ paletteIndex: extraWord & 0xf, bitPattern: 0x00 }],
+        cellColors: [ 0x02, 0x01, 0x03 ],
+        paramToScreen(param: number): number { return param & 0xff; },
+        paramToColorBlock(param: number): number { return param & 0x0f; },
+        extraArray(): Uint8Array | undefined {
+            let extra = new Uint8Array(2);
+            extra[0] = extraWord & 0xff;          // background color (and high nybble aux, which is N/A)
+            extra[1] = (extraWord >> 8) & 0xff;   // border color
+            return extra;
+        }
+    });
 }
 
 export function exportC64Hires(img: PixelsAvailableMessage, settings: DithertronSettings): Uint8Array {
-    if (!settings.block) throw "No block size";
-    let w = settings.block.w;
-    let h = settings.block.h;
-    let cols = img.width / w;
-    let rows = img.height / h;
-    let screen = new Uint8Array(cols * rows);
-    for (let i = 0; i < screen.length; i++) {
-        let p = img.params[i];
-        screen[i] = ((p & 0x0f) << 4) | ((p & 0xf0) >> 4);
-    }
-    let char = exportCharMemory(img, w, h);
-    let xtra = new Uint8Array(2);
-    let xtraword = img.params[img.params.length - 1]; // background, border colors
-    xtra[0] = xtraword & 0xff;          // background color
-    xtra[1] = (xtraword >> 8) & 0xff;   // border color
-    return concatArrays([char, screen, xtra]);
-}
 
-export function exportC64HiresFLI(img: PixelsAvailableMessage, settings: DithertronSettings): Uint8Array {
-    let screen = new Uint8Array(0x2000);
-    for (var i = 0; i < img.params.length; i++) {
-        let p = img.params[i];
-        let scrnofs = (Math.floor(i / 40) & 7) * 0x400 + Math.floor(i / 320) * 40 + (i % 40);
-        screen[scrnofs] = ((p & 0x0f) << 4) | ((p & 0xf0) >> 4);
-    }
-    let xtra = new Uint8Array(2);
-    let xtraword = img.params[img.params.length - 1]; // background, border colors
-    xtra[0] = xtraword & 0xff;          // background color
-    xtra[1] = (xtraword >> 8) & 0xff;   // border color
-    let char = exportCharMemory(img, 8, 8, 'fli');
-    return concatArrays([char, screen, xtra]);
+    let extraWord = img.params[img.params.length - 1]; // background, border colors
+
+    // lower nybble for bit pattern %0
+    // upper nybble for bit pattern %1
+
+    return exportVic({
+        img: img,
+        settings: settings,
+        globalColors: [],
+        cellColors: [ 0x01, 0x00 ],
+        paramToScreen(param: number): number { return ((param & 0x0f) << 4) | ((param & 0xf0) >> 4); },
+        paramToColorBlock(param: number): number { return 0; },
+        extraArray(): Uint8Array | undefined {
+            let extra = new Uint8Array(2);
+            extra[0] = extraWord & 0xff;          // background color (and high nybble aux, which is N/A)
+            extra[1] = (extraWord >> 8) & 0xff;   // border color
+            return extra;
+        }
+    });
 }
 
 export function exportVicHires(img: PixelsAvailableMessage, settings: DithertronSettings): Uint8Array {
-    // TODO:Test this with actual asm code, consider this pre-experimental and likely to fail in practice
-    if (!settings.block) throw "No block size";
-    let w = settings.block.w;
-    let h = settings.block.h;
-    let cols = img.width / w;
-    let rows = img.height / h;
-    let screen = new Uint8Array(cols * rows);
-    for (let i = 0; i < screen.length; i++) {
-        let p = img.params[i];
-        screen[i] = ((p & 0x0f) << 4) | ((p & 0xf0) >> 4);
-    }
-    // see exportVicMulti for more details
-    let char = exportCharMemory(img, w, h);
-    let xtra = new Uint8Array(2);
-    let xtraword = img.params[img.params.length - 1]; // background, border colors
-    xtra[0] = xtraword & 0xff;          // background color (and high nybble aux)
-    xtra[1] = (xtraword >> 8) & 0xff;   // border color
-    return concatArrays([char, screen, xtra]);
-}
 
-export function exportVicMulti(img: PixelsAvailableMessage, settings: DithertronSettings): Uint8Array {
-    // TODO:Test this with actual asm code, consider this pre-experimental and likely to fail in practice
-    if (!settings.block) throw "No block size";
-
-    let w = settings.block.w;
-    let h = settings.block.h;
-    let cols = img.width / w;
-    let rows = img.height / h;
-
-    let screen = new Uint8Array(cols * rows);
+    let extraWord = img.params[img.params.length - 1]; // background, border colors
 
     // From wiki entry that best describes:
     // The VIC-20 lacks any true graphic mode, but a 22×11 text mode with 200 definable characters of
@@ -295,22 +451,72 @@ export function exportVicMulti(img: PixelsAvailableMessage, settings: Dithertron
     //
     // In the 8-color high-res mode, every 8×8 pixels can have the background color (shared for the
     // entire screen) or a free foreground color, both selectable among the first eight colors of the
-    // palette. In the 10-color multicolor mode, a single pixel of every 4×8 block (a character cell)
+    // palette.
+    //
+    // Each possible one-bit value corresponds to a specific selectable color:
+    // %0 = screen color
+    // %1 = character/cell color
+
+    let backgroundColor = extraWord & 0x0f;
+    let borderColor = (extraWord >> 8) & 0x0f;
+    let auxColor = (extraWord >> 4) & 0x0f;
+
+    return exportVic({
+        img: img,
+        settings: settings,
+        globalColors: [{ paletteIndex: backgroundColor, bitPattern: 0x00 }],
+        cellColors: [ 0x01 ],
+        paramToScreen(param: number): number { return param & 0x0f; },
+        paramToColorBlock(param: number): number { return 0; },
+        extraArray(): Uint8Array | undefined {
+            let extra = new Uint8Array(3);
+            extra[0] = backgroundColor; // background color
+            extra[1] = borderColor;     // border color
+            extra[2] = auxColor;        // aux color
+            return extra;
+        }
+    });    
+}
+
+export function exportVicMulti(img: PixelsAvailableMessage, settings: DithertronSettings): Uint8Array {
+
+    let extraWord = img.params[img.params.length - 1]; // background, border colors
+
+    // In the 10-color multicolor mode, a single pixel of every 4×8 block (a character cell)
     // may have any of four colors: the background color, the auxiliary color (both shared for the
     // entire screen and selectable among the entire palette), the same color as the overscan border
     // (also a shared color) or a free foreground color, both selectable among the first eight colors
     // of the palette.
-    for (let i = 0; i < screen.length; i++) {
-        screen[i] = (img.params[i] & 0xff);
-    }
 
-    let char = exportCharMemory(img, w, h);
-    let xtraword = img.params[img.params.length - 1]; // background, border colors
-    let xtra = new Uint8Array(3);
-    xtra[0] = xtraword & 0x0f;          // background color
-    xtra[1] = (xtraword >> 8) & 0x0f;   // border color
-    xtra[2] = (xtraword >> 4) & 0x0f;   // aux color
-    return concatArrays([char, screen, xtra]);
+    // Each possible two-bit value corresponds to a specific selectable color:
+    // %00 = screen color
+    // %01 = border color
+    // %10 = character/cell color
+    // %11 = auxiliary color
+
+    let backgroundColor = extraWord & 0x0f;
+    let borderColor = (extraWord >> 8) & 0x0f;
+    let auxColor = (extraWord >> 4) & 0x0f;
+
+    return exportVic({
+        img: img,
+        settings: settings,
+        globalColors: [
+            { paletteIndex: backgroundColor, bitPattern: 0x00 },
+            { paletteIndex: borderColor, bitPattern: 0x01 },
+            { paletteIndex: auxColor, bitPattern: 0x03 }
+        ],
+        cellColors: [ 0x02 ],
+        paramToScreen(param: number): number { return param & 0x0f; },
+        paramToColorBlock(param: number): number { return 0; },
+        extraArray(): Uint8Array | undefined {
+            let extra = new Uint8Array(3);
+            extra[0] = backgroundColor; // background color
+            extra[1] = borderColor;     // border color
+            extra[2] = auxColor;        // aux color
+            return extra;
+        }
+    });
 }
 
 export function exportZXSpectrum(img: PixelsAvailableMessage, settings: DithertronSettings): Uint8Array {

--- a/src/settings/systems.ts
+++ b/src/settings/systems.ts
@@ -11,6 +11,7 @@ export const SYSTEMS: (DithertronSettings | null)[] = [
         conv: 'VICII_Canvas',
         pal: palettes.VIC_PAL_RGB,
         block: { w:4, h:8, colors:4, xb:1, yb:2 },
+        cell: {w: 4, h: 8, msbToLsb: true },
         paletteChoices:{background: true},        
         cb: { w: 4, h: 8, xb: 1, yb: 2 },
         toNative: 'exportC64Multi',
@@ -25,6 +26,7 @@ export const SYSTEMS: (DithertronSettings | null)[] = [
         pal: palettes.VIC_PAL_RGB,
         block: { w: 4, h: 1, colors: 4, xb: 1 },
         paletteChoices:{ background: true },
+        cell: {w: 4, h: 8, msbToLsb: true },
         cb: { w: 4, h: 8, xb: 1, yb: 2 },
         fli: { bug: false, blankLeft: false, blankRight: false, blankColumns: 3 },
         toNative: 'exportC64Multi',
@@ -38,6 +40,7 @@ export const SYSTEMS: (DithertronSettings | null)[] = [
         conv: 'VICII_Canvas',
         pal: palettes.VIC_PAL_RGB,
         block: { w: 4, h: 1, colors: 4, xb: 1 },
+        cell: {w: 4, h: 8, msbToLsb: true },
         paletteChoices: { background: true },
         cb: { w: 4, h: 8, xb: 1, yb: 2 },
         fli: { bug: true, blankLeft: false, blankRight: false, blankColumns: 3 },
@@ -52,6 +55,7 @@ export const SYSTEMS: (DithertronSettings | null)[] = [
         conv: 'VICII_Canvas',
         pal: palettes.VIC_PAL_RGB,
         block: { w: 4, h: 1, colors: 4, xb: 1 },
+        cell: {w: 4, h: 8, msbToLsb: true },
         paletteChoices: { background: true },
         cb: { w: 4, h: 8, xb: 1, yb: 2 },
         fli: { bug: false, blankLeft: true, blankRight: false, blankColumns: 3 },
@@ -66,6 +70,7 @@ export const SYSTEMS: (DithertronSettings | null)[] = [
         conv: 'VICII_Canvas',
         pal: palettes.VIC_PAL_RGB,
         block: { w: 4, h: 1, colors: 4, xb: 1 },
+        cell: {w: 4, h: 8, msbToLsb: true },
         paletteChoices: { background:true },
         cb: { w: 4, h: 8, xb: 1, yb: 2 },
         fli: { bug: false, blankLeft: true, blankRight: true, blankColumns: 3 },
@@ -80,6 +85,7 @@ export const SYSTEMS: (DithertronSettings | null)[] = [
         conv: 'VICII_Canvas',
         pal: palettes.VIC_PAL_RGB,
         block: { w: 8, h: 8, colors: 2 },
+        cell: {w: 8, h: 8, msbToLsb: true },
         toNative: 'exportC64Hires',
     },
     {
@@ -91,8 +97,9 @@ export const SYSTEMS: (DithertronSettings | null)[] = [
         conv: 'VICII_Canvas',
         pal: palettes.VIC_PAL_RGB,
         block: { w: 8, h: 1, colors: 2 },
+        cell: {w: 8, h: 8, msbToLsb: true },
         fli: { bug: false, blankLeft: false, blankRight: false, blankColumns: 3 },
-        toNative: 'exportC64HiresFLI',
+        toNative: 'exportC64Hires',
     },
     {
         id: 'c64.hires.fli.bug',
@@ -103,8 +110,9 @@ export const SYSTEMS: (DithertronSettings | null)[] = [
         conv: 'VICII_Canvas',
         pal: palettes.VIC_PAL_RGB,
         block: { w: 8, h: 1, colors: 2 },
+        cell: {w: 8, h: 8, msbToLsb: true },
         fli: { bug: true, blankLeft: false, blankRight: false, blankColumns: 3 },
-        toNative: 'exportC64HiresFLI',
+        toNative: 'exportC64Hires',
     },
     {
         id: 'c64.hires.fli.blank',
@@ -115,8 +123,9 @@ export const SYSTEMS: (DithertronSettings | null)[] = [
         conv: 'VICII_Canvas',
         pal: palettes.VIC_PAL_RGB,
         block: { w: 8, h: 1, colors: 2 },
+        cell: {w: 8, h: 8, msbToLsb: true },
         fli: { bug: false, blankLeft: true, blankRight: true, blankColumns: 3 },
-        toNative: 'exportC64HiresFLI',
+        toNative: 'exportC64Hires',
     },
     {
         id: 'vic20.hires',
@@ -127,6 +136,7 @@ export const SYSTEMS: (DithertronSettings | null)[] = [
         conv: 'VICII_Canvas',
         pal: palettes.VIC20_PAL_RGB,
         block: { w: 8, h: 8, colors: 2 },           // can choose the background, or one foreground color
+        cell: {w: 8, h: 8, msbToLsb: true },
         paletteChoices: {
             background: true,                       // pixels can choose the background color
             backgroundRange: { min: 0, max: 7 },    // (but with a reduced color palette)
@@ -143,6 +153,7 @@ export const SYSTEMS: (DithertronSettings | null)[] = [
         conv: 'VICII_Canvas',
         pal: palettes.VIC20_PAL_RGB,
         block: { w: 4, h: 8, colors: 4 },           // can choose background, aux, border and one foreground color
+        cell: {w: 8, h: 8, msbToLsb: true },
         paletteChoices: {
             background: true,                       // pixels can choose the background color
             backgroundRange: { min: 0, max: 15 },


### PR DESCRIPTION
The Vic 20 does not have a dedicated bitmap mode. However, due to its
screen resolution, it's possible to remap the character map allowing for
a pseudo bitmap from screen characters. Effectively the C64 does this
same model too internally, although it has dedicated text vs screen modes
to make this process more explicit as a bitmap mode.

The Vic 20 has two graphics mode capabilities, hires and multi. In hires
mode the Vic 20 can choose a character cell color or the common
background color from a restricted palette. In multi 10-color mode the
Vic 20 can choose the background, border, aux common colors or
from a character cell block color.

The code changes were made to accommodate the Vic 20:
- the vic export routines were split off from exportCharMemory as
that routines had too many assumptions related to how pixels
get mapped into patterns. A more generic and flexible
exportCellBuffer was created which handles both fli and non-fli,
c64 and vic 20 by allowing each configuration to pass in their
own global colors and cell pixel pattern mappings.

The export Vic routine further abstracts by providing helper
routines to convert the param into screen data (i.e.
put the nybbles into the correct screen position), handle FLI
(including the possibility of future Vic FLI), and allowing the
specialization of extra data on each platform while keeping
the logic entirely common across the platforms.

A helper routine was added to map integer value pixel
patterns onto an array buffer in a generic fashion.

The other target systems that are cell based could use this
new routine too but I did not update them as they work
and messing with them without having unit tests sounds
a bit dangerous.