### PR TITLE
Makefile on windows

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -13,6 +13,16 @@ setup:
 	@cp node_modules/cropperjs/dist/cropper.min.css ./lib/
 	@cp node_modules/bootstrap-slider/dist/css/bootstrap-slider.min.css ./lib/
 
+setupwin:
+	@if not exist ".\lib" mkdir .\lib  > nul
+	@copy /y node_modules\jquery\dist\jquery.min.js .\lib > nul
+	@copy /y node_modules\bootstrap\dist\js\bootstrap.bundle.min.js .\lib > nul
+	@copy /y node_modules\bootstrap-slider\dist\bootstrap-slider.min.js .\lib  > nul
+	@copy /y node_modules\font-awesome\css\font-awesome.min.css .\lib > nul
+	@copy /y node_modules\bootstrap\dist\css\bootstrap.min.css .\lib > nul
+	@copy /y node_modules\cropperjs\dist\cropper.min.css .\lib > nul
+	@copy /y node_modules\bootstrap-slider\dist\css\bootstrap-slider.min.css .\lib > nul
+
 watch:
 	npm run clean
 	sleep 9999999 | npm run esbuild-worker -- --watch &

--- a/README.md
+++ b/README.md
@@ -82,7 +82,7 @@ npm i
 ~~~~
 Build:
 ~~~~
-make setup
+make setup      (or "make setupwin" on Windows)
 npm run build
 ~~~~
 Watch:


### PR DESCRIPTION
I suggest you REJECT this PR. I just wanted to show why the Makefile fails on Windows. The @ commands don't work because they are using linux commands. The Makefile could be make to work on both systems. I'm not a Makefile expert though so I don't want to propose the "right" way to do it. distro/watch targets will have the same issues but they aren't as vital to get going.