### PR TITLE
Fix for busted NES ROM export

### DIFF
--- a/src/export/asm/nes.asm
+++ b/src/export/asm/nes.asm
@@ -97,3 +97,5 @@ Palette:
     org $10000
     ds 16	; blanks
     incbin "$DATAFILE"
+    incbin "$DATAFILE"
+    incbin "$DATAFILE"


### PR DESCRIPTION
Change in NES ASM template that duplicates image data to fill the block and make emulators happy.

(This follows the pattern taken in some of the sample NES ASM code, e.g. "[Hello World](https://8bitworkshop.com/v3.12.0/?platform=nes&file=ex1.dasm).")

| Before | After |
|-------|------|
| ![Mesen displays error](https://github.com/user-attachments/assets/af451f81-5530-49a1-9c5e-94991e101ce2) | ![Mesen loads ROM](https://github.com/user-attachments/assets/0d3b3cb3-e38f-4091-8a99-17e3e99da4a9) |